### PR TITLE
Make header sticky

### DIFF
--- a/app/components/blog/top-navigation.tsx
+++ b/app/components/blog/top-navigation.tsx
@@ -10,7 +10,7 @@ import { cn } from "@/lib/utils";
 
 export function TopNavigation() {
   return (
-    <header className="border-b relative z-50">
+    <header className="border-b sticky top-0 bg-background/80 backdrop-blur-sm z-50">
       <div className="container mx-auto px-4 py-3 flex items-center justify-between">
         <div className="flex items-center gap-6">
           <h1 className="text-xl font-serif">

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -35,7 +35,7 @@ export default function Index() {
       <TopNavigation />
 
       {/* Tags Navigation */}
-      <nav className="border-b sticky top-0 bg-background/80 backdrop-blur-sm relative z-50">
+      <nav className="border-b sticky top-14 bg-background/80 backdrop-blur-sm relative z-50">
         <div className="container mx-auto px-4">
           <TagFilter
             tags={tags}


### PR DESCRIPTION
## Summary
- keep the top navigation bar visible by making it sticky
- offset the tag filter nav so that it remains below the header

## Testing
- `yarn lint` *(fails: package missing in lockfile)*
- `yarn test:e2e` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_684317de54e88333acee690f9eee7cd8